### PR TITLE
feat: Move device params to res/devices/sample-devices.yaml

### DIFF
--- a/cmd/res/devices/devices.yaml
+++ b/cmd/res/devices/devices.yaml
@@ -8,7 +8,7 @@ deviceList:
       - uart-generice-device
     protocols:
       UART:
-        deviceName: "/dev/ttyAMA2"
+        deviceLocation: "/dev/ttyAMA2"
         baudRate: 115200
     # autoEvents:
     #   - Interval: 20s

--- a/cmd/res/profiles/generic.yaml
+++ b/cmd/res/profiles/generic.yaml
@@ -10,7 +10,7 @@ deviceResources:
     name: "Read_UART"
     isHidden: false
     description: "used to read from the UART device"
-    attributes: { type: "generic", dev: "/dev/ttyAMA2", baud: 115200, maxbytes: 160, timeout: 1}
+    attributes: { type: "generic", maxbytes: 160, timeout: 1}
     properties:
         valueType: "String"
         readWrite: "R"
@@ -18,7 +18,7 @@ deviceResources:
     name: "Write_UART"
     isHidden: false
     description: "used to write to the UART device"
-    attributes: { type: "generic", dev: "/dev/ttyAMA2", baud: 115200, timeout: 1}
+    attributes: { type: "generic", timeout: 1}
     properties:
         valueType: "String"
         readWrite: "W"


### PR DESCRIPTION
Move device parameters such as device name and baud rate to res/devices/sample-devices.yaml

Addresses #15 

## PR Checklist

- [N] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [N] I am not introducing a new dependency (add notes below if you are)
- [N] I have added unit tests for the new feature or bug fix (if not, why?)
- [Y] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
1. Run the edgex-go microservices.
2. Run the device-uart microservice.
3. Execute the below commands from a terminal. Ensure that the deviceName, baudRate are parsed correctly from res/devices/devices.yaml and not present under attributes list since it is removed from res/profiles/generic.yaml
```
curl -X GET http://localhost:59881/api/v3/device/name/Uart-Generic-Device | json_pp
curl -X GET http://localhost:59881/api/v3/deviceprofile/name/Uart-Generic-Device | json_pp
```
Note: Attached the test logs.

## New Dependency Instructions (If applicable)
N/A
[Test-Log_Feature_Move-Device-Params-to-Device-File_CURL+Device-UART.txt](https://github.com/edgexfoundry/device-uart/files/12017842/Test-Log_Feature_Move-Device-Params-to-Device-File_CURL%2BDevice-UART.txt)
